### PR TITLE
Update to handle update in webcolors

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -55,13 +55,13 @@ class LifxSkill(MycroftSkill):
             self.log.warning("ERROR DISCOVERING LIFX LIGHTS. FUNCTIONALITY MIGHT BE WONKY.\n{}".format(str(e)))
         if len(self.targets.items()) == 0:
             self.log.warn("NO LIGHTS FOUND DURING SEARCH. FUNCTIONALITY MIGHT BE WONKY.")
-        for color_name in webcolors.css3_hex_to_names.values():
+        for color_name in webcolors.CSS3_HEX_TO_NAMES.values():
             self.register_vocabulary(color_name, "Color")
 
     @property
     def dim_step(self):
         return int(float(self.settings.get("percent_step", 0.25)) * MAX_VALUE)
-    
+
     @property
     def transition_time_ms(self):
         return int(self.settings.get("transition_time", 1250))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 #This file is a list of all pip requirements for your skill (if needed)
-webcolors
+webcolors>=1.11.1
 fuzzywuzzy
 lifxlan


### PR DESCRIPTION
When checking community skill compatibility with v20.02 I noticed that lifx wouldn't load. Seems like changes in webcolors make it fail. This PR makes the skill require the current version and update the color name fetcher.